### PR TITLE
correct line 294 referencing import statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ gryffMascot();
 ```js
 // src/Hogwarts.js
 import { colors } from './houses/Gryffindor.js';
-import { mascot as gryffMascot } from './houses/Gryffindor.js';
+import { gryffMascot as mascot } from './houses/Gryffindor.js';
 
 colors();
 // > 'Scarlet and Gold'


### PR DESCRIPTION
on line 294, I corrected the import statement which was as follows:
import { mascot as gryffMascot } from './houses/Gryffindor.js';	

I made the following change since the original export was gryffMascot instead of mascot:
import { gryffMascot as mascot } from './houses/Gryffindor.js';
